### PR TITLE
Fix name typo in news article

### DIFF
--- a/news.html
+++ b/news.html
@@ -497,7 +497,7 @@
                                 <img src="./Images/2025/ScottishQ/20250624_193855.jpg" alt="Gary Malcolmson in action during the District Singles Final" class="zoomable-image" onclick="openLightbox(this)">
                             </div>
                             
-                            <p>Gary Malcolmson, who had battled his way to the final of the District Singles Qualifying round, put in a strong performance but was ultimately defeated 21–16 by Kevin Frogly of Borestone Bowling Club. While the result didn't go Gary's way this time, his run to the final has been a fantastic achievement and he can hold his head high.</p>
+                            <p>Gary Malcolmson, who had battled his way to the final of the District Singles Qualifying round, put in a strong performance but was ultimately defeated 21–16 by Kevin Frogley of Borestone Bowling Club. While the result didn't go Gary's way this time, his run to the final has been a fantastic achievement and he can hold his head high.</p>
                             
                             <p>Meanwhile, in the District Pairs Final, Aaron Furzer and William Black delivered a dominant performance against father and son duo Alan and Robert Hunter Snr of Alva. With precision and teamwork, the Polmaise pair secured a convincing victory of 22-6 with 1 end left to play and now advance to the Scottish National Championships in Ayr later this summer.</p>
                             


### PR DESCRIPTION
## Summary
- correct Kevin Frogly to Kevin Frogley in June 24, 2025 news post

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d0c549284832c88385f9fa623ae7e