### PR TITLE
Fix name on honours page

### DIFF
--- a/honours.html
+++ b/honours.html
@@ -207,7 +207,7 @@
                             <li>St. Dunstans Trophy</li>
                             <li>Duncan Trophy</li>
                             <li>Reid Trophy</li>
-                            <li>Scottish Area Pairs: J. Brown & A. Furzel</li>
+                            <li>Scottish Area Pairs: J. Brown & A. Furzer</li>
                             <li>Area & District Champion of Champions: G. Malcolmson</li>
                         </ul>
                     </div>


### PR DESCRIPTION
## Summary
- fix spelling of A. Furzer on Honours & Achievements page

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685d0e62d6e4832cb0d6abb0dac52761