### PR TITLE
Update 2025 honours with new Area Pairs winners

### DIFF
--- a/honours.html
+++ b/honours.html
@@ -172,6 +172,7 @@
                     <div class="year-achievements">
                         <ul>
                             <li>Top 9 Indoor Champions</li>
+                            <li>Scottish Area Pairs: W. Black & A. Furzer</li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- update honours page with W. Black & A. Furzer as 2025 Scottish Area Pairs winners

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d0fde8e44832c9fd9bcebb0105562