### PR TITLE
Update honours for 2025

### DIFF
--- a/honours.html
+++ b/honours.html
@@ -173,6 +173,7 @@
                         <ul>
                             <li>Top 9 Indoor Champions</li>
                             <li>Scottish Area Pairs: W. Black & A. Furzer</li>
+                            <li>County Triples: Gary Malcomson, William Black, Stephen Flemming</li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add County Triples winners for 2025 to honours page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873dd8e425c832c8d617b7aefdfebb0